### PR TITLE
Add new NavBar icons

### DIFF
--- a/extra/scalable/actions/navbar-closed-symbolic.svg
+++ b/extra/scalable/actions/navbar-closed-symbolic.svg
@@ -1,0 +1,10 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="path-1-inside-1_3277_252" fill="white">
+<rect x="1" y="2" width="14" height="12" rx="1"/>
+</mask>
+<rect x="1" y="2" width="14" height="12" rx="1" stroke="#232323" stroke-width="4" mask="url(#path-1-inside-1_3277_252)"/>
+<rect x="6" y="2" width="2" height="12" fill="#232323"/>
+<rect x="4" y="5" width="1" height="1" fill="#232323"/>
+<rect x="4" y="7" width="1" height="1" fill="#232323"/>
+<rect x="4" y="9" width="1" height="1" fill="#232323"/>
+</svg>

--- a/extra/scalable/actions/navbar-open-symbolic.svg
+++ b/extra/scalable/actions/navbar-open-symbolic.svg
@@ -1,0 +1,8 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<mask id="path-1-inside-1_3277_253" fill="white">
+<rect x="1" y="2" width="14" height="12" rx="1"/>
+</mask>
+<rect x="1" y="2" width="14" height="12" rx="1" stroke="#232323" stroke-width="4" mask="url(#path-1-inside-1_3277_253)"/>
+<rect x="5" y="2" width="2" height="12" fill="#232323"/>
+<path d="M7.99983 8.02603L10.9998 5C10.9998 5 11.5568 4.55672 12 5.00002C12.4432 5.44331 12 6.00002 12 6.00002L10 8.02603L12 10C12 10 12.5 10.5 12 11C11.5 11.5 11 11 11 11L7.99983 8.02603Z" fill="#232323"/>
+</svg>


### PR DESCRIPTION
Fixes #22.
The `open-menu-symbolic` icon will be used for the collapsed menus (File, Edit,...), but not sure if `close-menu-symbolic` should be removed.