### PR TITLE
Add tab-new-symbolic icon

### DIFF
--- a/extra/scalable/actions/tab-new-symbolic.svg
+++ b/extra/scalable/actions/tab-new-symbolic.svg
@@ -1,0 +1,1 @@
+<svg viewBox='0 0 16 16' xmlns='http://www.w3.org/2000/svg'><g transform='translate(-340 -56)'><path d='M344 58.003s-2 0-2 2v7c0 1-1 1-1 1h-1v2h16v-2h-1s-1 0-1-1v-7s0-2-2-2zm3 2h2v3h3v2h-3v3h-2v-3h-3v-2h3z' fill='#232323'/></g></svg>


### PR DESCRIPTION
I noticed when using ghostty the new-tab-symbolic icon is missing from the Cosmic icon set. I have copied it from the Pop icon set as I couldn't see a problem with that. 

Let me know if it needs to be changed at all. 