### PR TITLE
Update Trash Icons

### DIFF
--- a/freedesktop/scalable/places/user-trash.svg
+++ b/freedesktop/scalable/places/user-trash.svg
@@ -1,1 +1,116 @@
-<svg version="1.0" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg"><path d="M56 16c-8.864 0-16.707 7.164-16 16l16 200c36 20 108 20 144 0l16-200c.707-8.836-7.136-16-16-16z" fill="#898989"/><path d="M56 16c-8.864 0-16.707 7.164-16 16l16 200c36 20 108 20 144 0l16-200c.707-8.836-7.136-16-16-16zm0 1h144c8.31 0 15 6.69 15 15l-16 195c-36 20-106 20-142 0L41 32c0-8.31 6.69-15 15-15z" fill-opacity=".5"/><g fill="none" stroke-width="2"><path d="M129 35.54v192" opacity=".35" stroke="#000"/><path d="M127 35.54v192" opacity=".35" stroke="#fff"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.0"
+   viewBox="0 0 256 256"
+   id="svg4"
+   sodipodi:docname="user-trash.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath39">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse39"
+         cx="-292.61725"
+         cy="39.55172"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath38">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse38"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath37">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse37"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath36">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse36"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse35"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath34">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse34"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.4375"
+     inkscape:cx="34.782609"
+     inkscape:cy="133.56522"
+     inkscape:window-width="1904"
+     inkscape:window-height="923"
+     inkscape:window-x="8"
+     inkscape:window-y="40"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <g
+     id="g9"
+     style="display:inline;fill:#f0f1f1;fill-opacity:1"
+     transform="matrix(1.3431938,0,0,1.3431938,544.45458,-115.18342)">
+    <path
+       id="path5-6"
+       style="fill:#f0f1f1;fill-opacity:1;stroke-width:0.960602"
+       d="m -156.95703,41.912109 a 68.608696,17.130434 0 0 0 -68.60742,17.13086 68.608696,17.130434 0 0 0 0.0937,0.898437 l 14.61132,139.716794 a 53.501171,19.834076 0 0 0 53.50196,19.83399 53.501171,19.834076 0 0 0 53.5,-19.83399 L -88.451172,59.988281 v -0.002 a 68.608696,17.130434 0 0 0 0.103516,-0.943359 68.608696,17.130434 0 0 0 -68.609374,-17.13086 z"
+       transform="translate(-152.48911,52.860053)" />
+    <ellipse
+       style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+       id="path5-5"
+       cx="-309.44614"
+       cy="111.9026"
+       rx="68.608696"
+       ry="17.130434" />
+  </g>
+</svg>

--- a/freedesktop/scalable/status/user-trash-full.svg
+++ b/freedesktop/scalable/status/user-trash-full.svg
@@ -1,1 +1,231 @@
-<svg version="1.0" viewBox="0 0 256 256" xmlns="http://www.w3.org/2000/svg"><path d="M56 16c-8.864 0-16.707 7.164-16 16l16 200c36 20 108 20 144 0l16-200c.707-8.836-7.136-16-16-16z" fill="#898989"/><path d="M56 16c-8.864 0-16.707 7.164-16 16l16 200c36 20 108 20 144 0l16-200c.707-8.836-7.136-16-16-16zm0 1h144c8.31 0 15 6.69 15 15l-16 195c-36 20-106 20-142 0L41 32c0-8.31 6.69-15 15-15z" fill-opacity=".5"/><g stroke-width=".5"><path d="M88 88 68 72l20-28 12 12 28-24 40 16 16 28-32 16 4 32-28 12-12-20-36 8-12-20z" fill="#ededed"/><path d="m100 56 22 22 14 22" fill="none" stroke="#898989" stroke-width="2"/></g><g stroke-width=".5"><path d="m114.228 117.025 12.753-22.211 30.729 15.482-10.024 13.694 28 24-9.694 41.976-25.223 20.094-20.706-29.176-31.011 8.846-16.141-25.835 17.929-14.917-13.412-34.353 17.93-14.917z" fill="#ededed"/><path d="m147.686 123.99-18.376 25.106-19.6 17.2" fill="none" stroke="#898989" stroke-width="2"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.0"
+   viewBox="0 0 256 256"
+   id="svg4"
+   sodipodi:docname="user-trash-full.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs4">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath39">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse39"
+         cx="-292.61725"
+         cy="39.55172"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath38">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse38"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath37">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse37"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath36">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse36"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse35"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath34">
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="ellipse34"
+         cx="-155.40063"
+         cy="59.189125"
+         rx="68.608696"
+         ry="17.130434" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.4375"
+     inkscape:cx="34.086957"
+     inkscape:cy="133.56522"
+     inkscape:window-width="1904"
+     inkscape:window-height="923"
+     inkscape:window-x="8"
+     inkscape:window-y="40"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <g
+     id="g40"
+     transform="matrix(1.3431938,0,0,1.3431938,818.62696,-45.310229)"
+     style="display:inline">
+    <g
+       id="g9-6"
+       style="fill:#f0f1f1;fill-opacity:1"
+       transform="translate(-204.11975,-52.022179)">
+      <path
+         id="path5-6-2"
+         style="fill:#f0f1f1;fill-opacity:1;stroke-width:0.960602"
+         d="m -156.95703,41.912109 a 68.608696,17.130434 0 0 0 -68.60742,17.13086 68.608696,17.130434 0 0 0 0.0937,0.898437 l 14.61132,139.716794 a 53.501171,19.834076 0 0 0 53.50196,19.83399 53.501171,19.834076 0 0 0 53.5,-19.83399 L -88.451172,59.988281 v -0.002 a 68.608696,17.130434 0 0 0 0.103516,-0.943359 68.608696,17.130434 0 0 0 -68.609374,-17.13086 z"
+         transform="translate(-152.48911,52.860053)" />
+      <ellipse
+         style="fill:#e0e1e1;fill-opacity:1;stroke-width:1.01095"
+         id="path5-5-9"
+         cx="-309.44614"
+         cy="111.9026"
+         rx="68.608696"
+         ry="17.130434" />
+    </g>
+    <g
+       id="g39"
+       transform="translate(-357.63347,0.01170001)">
+      <g
+         id="g8"
+         transform="translate(137.21662,19.637404)"
+         style="display:inline;fill:#f0f1f1;fill-opacity:1"
+         clip-path="url(#clipPath39)" />
+      <g
+         id="g21"
+         style="display:inline">
+        <path
+           style="display:inline;fill:#a252d2;fill-opacity:1"
+           d="m -193.82609,53.565217 2.08696,6.695653 6.6087,8.434782 19.82608,-17.391304 -1.65217,-7.130435 z"
+           id="path12" />
+        <path
+           style="display:inline;fill:#c55ff8;fill-opacity:1"
+           d="m -193.82609,53.565217 8.17392,-14.086956 18.69565,4.695652 -7.21739,12.869565 z"
+           id="path11" />
+      </g>
+      <g
+         id="g22"
+         style="display:inline"
+         clip-path="url(#clipPath38)">
+        <path
+           style="display:inline;fill:#a252d2;fill-opacity:1"
+           d="m -217.66591,65.053824 2.88991,10.329908 27.11601,0.922313 2.88991,-8.054869 -6.45619,-10.698833 z"
+           id="path10" />
+        <path
+           style="display:inline;fill:#c55ff8;fill-opacity:1"
+           d="m -203.64675,47.837311 12.42048,9.715032 -13.03536,15.863787 -13.40428,-8.362306 z"
+           id="path9" />
+      </g>
+      <g
+         id="g18"
+         style="display:inline">
+        <path
+           style="fill:#d38f00;fill-opacity:1"
+           d="M -157.13043,50.608696 V 61.73913 l 21.3913,5.130435 7.04348,-9.565217 -0.52174,-10.26087 -13.95652,3.304348 z"
+           id="path18"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="display:inline;fill:#ea9e00;fill-opacity:1"
+           d="M -143.73913,36.695652 -129.21739,47.043478 -143.04348,60 -157.13043,50.608696 Z"
+           id="path17" />
+      </g>
+      <g
+         id="g19"
+         style="display:inline">
+        <path
+           style="display:inline;fill:#d38f00;fill-opacity:1"
+           d="m -172.26087,56 -7.52872,6.840272 18.01586,10.760321 L -160,69.869565 -171.04968,55.047791 Z"
+           id="path16" />
+        <path
+           style="display:inline;fill:#ea9e00;fill-opacity:1"
+           d="M -162.43478,48.391304 C -162.65217,48.434783 -172.26087,56 -172.26087,56 l 10.34783,13.391304 c 0,0 1,0.913044 1.91304,0.478261 0.91304,-0.434782 13.30435,-7.391304 13.30435,-7.391304 z"
+           id="path15" />
+      </g>
+      <g
+         id="g20"
+         style="display:inline"
+         clip-path="url(#clipPath37)">
+        <path
+           style="display:inline;fill:#26a5b3;fill-opacity:1"
+           d="M -189.65217,74.608696 -180.17391,62 l 17.21739,6.521739 -5.47826,8.956522 z"
+           id="path13" />
+        <path
+           style="display:inline;fill:#05919f;fill-opacity:1"
+           d="m -162.95652,68.521739 1.79766,8.399181 -7.27592,0.557341 z"
+           id="path14" />
+      </g>
+      <g
+         id="g27"
+         clip-path="url(#clipPath36)">
+        <path
+           style="fill:#35b73f;fill-opacity:1"
+           d="m -114.98171,52.264414 19.737501,14.572549 -12.051561,11.375196 -18.93816,-6.51768 4.42575,-9.642847 z"
+           id="path27" />
+        <path
+           style="fill:#59cb54;fill-opacity:1"
+           d="m -114.98171,52.264414 0.92231,12.236022 15.310401,7.747431 3.50479,-5.410904 1.045288,-5.164954 z"
+           id="path26" />
+      </g>
+      <g
+         id="g23"
+         style="display:inline"
+         clip-path="url(#clipPath35)">
+        <path
+           style="fill:#05919f;fill-opacity:1"
+           d="m -143.73913,52.956522 -5.73913,11.478261 13.21739,12 14,-2.086957 4.52174,-10.608695 z"
+           id="path23" />
+        <path
+           style="fill:#26a5b3;fill-opacity:1"
+           d="m -143.73913,52.956522 14.34783,-3.304348 11.65217,14.086957 -16.78261,4.782608 z"
+           id="path22" />
+      </g>
+      <g
+         id="g25"
+         style="display:inline"
+         clip-path="url(#clipPath34)">
+        <path
+           style="fill:#35b73f;fill-opacity:1"
+           d="m -158,65.478261 -5.21739,11.73913 11.13043,-0.695652 z"
+           id="path25" />
+        <path
+           style="fill:#59cb54;fill-opacity:1"
+           d="M -136.17391,59.391304 -158,65.478261 l 6.34783,14.086956 21.13043,-4.086956 z"
+           id="path24" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
This PR proposes updated trash icons for the Pop!_OS icon theme, including both empty and full states. 

The new design improves visual clarity and consistency with the Cosmic theme, while keeping the overall style cohesive with the existing icon set. 

Screenshots of the new icons compared to the current ones are included for reference.
<img width="1366" height="768" alt="new_trash" src="https://github.com/user-attachments/assets/f890378c-b29b-4253-81da-797883fa47d2" />
